### PR TITLE
Update pod-priority-preemption.md

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -51,7 +51,7 @@ PriorityClassオブジェクトのメタデータの`name`フィールドにて�
 値が大きいほど、高い優先度を示します。
 PriorityClassオブジェクトの名称は[DNSサブドメイン名](/ja/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)として適切であり、かつ`system-`から始まってはいけません。
 
-PriorityClassオブジェクトは10億以下の任意の32ビットの整数値を持つことができます。
+PriorityClassオブジェクトは、-2147483648から1000000000までの任意の32ビットの整数値を持つことができます。
 それよりも大きな値は通常はプリエンプトや追い出すべきではない重要なシステム用のPodのために予約されています。
 クラスターの管理者は割り当てたい優先度に対して、PriorityClassオブジェクトを1つずつ作成すべきです。
 


### PR DESCRIPTION
the change translates to "The PriorityClass object can have any 32-bit integer value from -2147483648 to 1000000000."

This translation includes the mention of the negative range, which is important to include because it allows readers to understand the full range of values that a PriorityClass object can have.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
